### PR TITLE
Update repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "style primitive React interfaces with glamorous",
   "version": "2.1.1",
   "main": "lib/index.js",
-  "repository": "github.com/nitin42/glamorous-primitives",
+  "repository": "nitin42/glamorous-primitives",
   "author": "Nitin Tulswani",
   "keywords": [
     "react",


### PR DESCRIPTION
Right now this repository is not linked on https://npm.im/glamorous-primitives because there is no protocol given on the repository field (i.e., `http://`). That said, npm does support a shorthand of `<github_username>/<repository_name>` which I used for this PR.